### PR TITLE
Update _titatoggle.less

### DIFF
--- a/dist/_titatoggle.less
+++ b/dist/_titatoggle.less
@@ -136,6 +136,21 @@ Main Slider
 
 }
 
+/**
+ * Fix an an issue with ".form-horizontal" forms use titatoggle.
+ *
+ * @see https://github.com/kleinejan/titatoggle/issues/5
+ */
+.form-horizontal {
+	.checkbox.checkbox-slider {
+		input + span {
+			&:after {
+				top: 7px;
+			}
+		}
+	}
+}
+
 
 /*******************************************************
 Slider default


### PR DESCRIPTION
This should fix the issue https://github.com/kleinejan/titatoggle/issues/5. I did the update on my working copy (on the `titatoggle-dist.css` file) and it works fine.

My css fix looks like this:
```css
.form-horizontal .checkbox.checkbox-slider--default input + span:after,
.form-horizontal .checkbox.checkbox-slider--a-rounded input + span:after,
.form-horizontal .checkbox.checkbox-slider--a input + span:after,
.form-horizontal .checkbox.checkbox-slider--b input + span:after,
.form-horizontal .checkbox.checkbox-slider--b-flat input + span:after,
.form-horizontal .checkbox.checkbox-slider--c input + span:after,
.form-horizontal .checkbox.checkbox-slider--c-weight input + span:after {
    top: 7px;
}
```